### PR TITLE
BIGFIX in first and third part, division by zero error

### DIFF
--- a/firstPart.c
+++ b/firstPart.c
@@ -34,6 +34,7 @@ double complex firstPart(const double Tolerance, const int l, const int m, const
   int * degnrtDOF = NULL;
   int * arrayPmode= NULL;
   
+  int niter = 0;
   int genReturn;
   genReturn = gen_points_array(&degnrtDOF, &arrayPmode, NPmode, DimMAX);
 
@@ -124,12 +125,18 @@ double complex firstPart(const double Tolerance, const int l, const int m, const
     firstPartSum += pmodeSum;
     //Both pmodeSum and firstPartSum are complex numbers,
     //cabs take the mode of these variables.
-    error = cabs(pmodeSum) / cabs(firstPartSum);
+    // only calculate new error if firstPartSum != 0.
+    if (firstPartSum != 0.)
+      error = cabs(pmodeSum) / cabs(firstPartSum);
     
     if(verbose)
       printf("pmode%d error: %.16f\n\n",pmodeSqur , error);
     
+    // if the result is still zero after 4 iterations it is assumed to stay zero
+    if (result == 0. && niter > 4)
+      break;
     pmodeSqur += 1;
+    ++niter;
     
   }//end of while.
   

--- a/firstPart.c
+++ b/firstPart.c
@@ -133,7 +133,7 @@ double complex firstPart(const double Tolerance, const int l, const int m, const
       printf("pmode%d error: %.16f\n\n",pmodeSqur , error);
     
     // if the result is still zero after 4 iterations it is assumed to stay zero
-    if (result == 0. && niter > 4)
+    if (firstPartSum == 0. && niter > 4)
       break;
     pmodeSqur += 1;
     ++niter;

--- a/thirdPart.c
+++ b/thirdPart.c
@@ -126,14 +126,14 @@ double complex thirdPart(const double Tolerance, const int l, const int m, doubl
 		//Both pmodeSum and firstPartSum are complex numbers,
 		//cabs take the mode of these variables.
     // only calculate new error if firstPartSum != 0.
-    if (firstPartSum != 0.)
+    if (thirdPartSum != 0.)
       error = cabs(pmodeSum) / cabs(firstPartSum);
 		
 		if(verbose)
 			printf("pmode=%d error: %.16f\n\n",pmodeSqur , error);
 	
     // if the result is still zero after 4 iterations it is assumed to stay zero
-    if (result == 0. && niter > 4)
+    if (thirdPartSum == 0. && niter > 4)
       break;
 		pmodeSqur += 1;
     ++niter;

--- a/thirdPart.c
+++ b/thirdPart.c
@@ -38,6 +38,7 @@ double complex thirdPart(const double Tolerance, const int l, const int m, doubl
 	int * arrayPmode= NULL;
 
 	
+        int niter = 0;
 	int genReturn;
 	genReturn = gen_points_array(&degnrtDOF, &arrayPmode, NPmode, DimMAX);
 	
@@ -124,12 +125,18 @@ double complex thirdPart(const double Tolerance, const int l, const int m, doubl
     thirdPartSum += pmodeSum;
 		//Both pmodeSum and firstPartSum are complex numbers,
 		//cabs take the mode of these variables.
-  	error = cabs(pmodeSum) / cabs(thirdPartSum);  
+    // only calculate new error if firstPartSum != 0.
+    if (firstPartSum != 0.)
+      error = cabs(pmodeSum) / cabs(firstPartSum);
 		
 		if(verbose)
 			printf("pmode=%d error: %.16f\n\n",pmodeSqur , error);
 	
+    // if the result is still zero after 4 iterations it is assumed to stay zero
+    if (result == 0. && niter > 4)
+      break;
 		pmodeSqur += 1;
+    ++niter;
 
 	}//end of while.
       


### PR DESCRIPTION
There was a false behaviour for the following input parameters:
l=4, m=0, gamma=1., q2 = 0.001, d = (0, 0, 0)

The first part should give a result of 0.545818004198 + 0i but gave 0. + 0.i due to a division by zero.